### PR TITLE
Add basic story session framework

### DIFF
--- a/forum_engine.py
+++ b/forum_engine.py
@@ -47,6 +47,14 @@ MESSAGE_LIMIT = 60  # limit before the forum glitches and resets
 NEW_USER = True
 
 
+def respond_as_character(name: str, history: List[Dict[str, str]]) -> str:
+    """Return a response from a specific character using provided history."""
+    func = AGENTS.get(name)
+    if not func:
+        raise ValueError(f"Unknown agent: {name}")
+    return func(history)
+
+
 def _pick_agents(count: int = 2) -> List[str]:
     return random.sample(list(AGENTS.keys()), k=count)
 

--- a/main.py
+++ b/main.py
@@ -50,6 +50,7 @@ from utils.config import (
     schedule_lit_check,
     schedule_identity_reflection,
 )
+from utils.story_engine import StorySessionManager
 from utils.resonator import schedule_resonance_creation, create_resonance_now
 import utils.resonator as resonator
 from utils.howru import schedule_howru
@@ -81,6 +82,9 @@ CHAT_HISTORY = {}
 PENDING_DRAFT = {}
 MAX_HISTORY_MESSAGES = 7
 MAX_PROMPT_TOKENS = 8000
+
+# Story sessions
+STORY_MANAGER = StorySessionManager()
 
 # Initialize OpenAI client
 openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
@@ -851,9 +855,24 @@ def handle_text_message(msg):
     
     if is_spam(user_id, text):
         return None
-    
+
     if not should_reply_to_message(msg):
         return None
+
+    # Story session commands
+    lower = text.lower()
+    if lower.startswith("/story_start"):
+        result = STORY_MANAGER.start_session(user_id)
+        choices = "\n".join(f"{i+1}. {c}" for i, c in enumerate(result["choices"]))
+        send_telegram_message(chat_id, f"{result['text']}\n\n{choices}", reply_to_message_id=message_id)
+        return result["text"]
+    if lower.startswith("/story_choice"):
+        parts = text.split(maxsplit=1)
+        choice = parts[1] if len(parts) > 1 else ""
+        result = STORY_MANAGER.add_choice(user_id, choice)
+        choices = "\n".join(f"{i+1}. {c}" for i, c in enumerate(result["choices"]))
+        send_telegram_message(chat_id, f"{result['text']}\n\n{choices}", reply_to_message_id=message_id)
+        return result["text"]
 
     # Display voice keyboard on /voice command
     if text.lower().strip() in ("/voice", "voice"):
@@ -890,7 +909,7 @@ def handle_text_message(msg):
                 send_telegram_typing(chat_id)
                 
                 # Search in memory (vectorized files and logs)
-                results = search_memory(query)
+                results = search_memory(query, user_id=user_id)
                 
                 # Now ask SUPPERTIME to process these results
                 if results and not results.startswith("No "):

--- a/utils/config.py
+++ b/utils/config.py
@@ -4,6 +4,7 @@ import json
 import hashlib
 import threading
 import time
+from typing import Optional
 
 from utils.whatdotheythinkiam import reflect_on_readme
 
@@ -16,20 +17,27 @@ if not os.path.isdir(LIT_DIR):
     if os.path.isdir(fallback):
         LIT_DIR = fallback
 
-SNAPSHOT_PATH = os.path.join(SUPPERTIME_DATA_PATH, "vectorized_snapshot.json")
+def _get_snapshot_path(user_id: Optional[str] = None) -> str:
+    if user_id:
+        base = os.path.join(SUPPERTIME_DATA_PATH, "memory", user_id)
+    else:
+        base = SUPPERTIME_DATA_PATH
+    return os.path.join(base, "vectorized_snapshot.json")
 
 
-def _load_snapshot():
+def _load_snapshot(user_id: Optional[str] = None):
+    snapshot_path = _get_snapshot_path(user_id)
     try:
-        with open(SNAPSHOT_PATH, "r", encoding="utf-8") as f:
+        with open(snapshot_path, "r", encoding="utf-8") as f:
             return json.load(f)
     except Exception:
         return {}
 
 
-def _save_snapshot(snapshot):
-    os.makedirs(os.path.dirname(SNAPSHOT_PATH), exist_ok=True)
-    with open(SNAPSHOT_PATH, "w", encoding="utf-8") as f:
+def _save_snapshot(snapshot, user_id: Optional[str] = None):
+    snapshot_path = _get_snapshot_path(user_id)
+    os.makedirs(os.path.dirname(snapshot_path), exist_ok=True)
+    with open(snapshot_path, "w", encoding="utf-8") as f:
         json.dump(snapshot, f, ensure_ascii=False, indent=2)
 
 
@@ -41,13 +49,13 @@ def _file_hash(path):
         return ""
 
 
-def vectorize_lit_files():
+def vectorize_lit_files(user_id: Optional[str] = None):
     """Vectorize new or updated literary files."""
     lit_files = glob.glob(os.path.join(LIT_DIR, "*.txt")) + glob.glob(os.path.join(LIT_DIR, "*.md"))
     if not lit_files:
         return "No literary files found in the lit directory."
 
-    snapshot = _load_snapshot()
+    snapshot = _load_snapshot(user_id)
     changed = []
     for path in lit_files:
         h = _file_hash(path)
@@ -61,20 +69,20 @@ def vectorize_lit_files():
             except Exception as e:
                 print(f"[SUPPERTIME][ERROR] Failed to vectorize {path}: {e}")
     if changed:
-        _save_snapshot(snapshot)
+        _save_snapshot(snapshot, user_id)
         return f"Indexed {len(changed)} files."
     return "No new literary files to index."
 
 
-def get_vectorized_files():
+def get_vectorized_files(user_id: Optional[str] = None):
     """Return list of vectorized literary files."""
-    snapshot = _load_snapshot()
+    snapshot = _load_snapshot(user_id)
     return list(snapshot.keys())
 
 
-def search_lit_files(query):
+def search_lit_files(query, user_id: Optional[str] = None):
     """Search vectorized literary files for a query."""
-    lit_files = get_vectorized_files()
+    lit_files = get_vectorized_files(user_id)
     if not lit_files:
         return "No literary files have been indexed yet."
 
@@ -130,9 +138,9 @@ def _search_logs(query):
     return hits
 
 
-def search_memory(query):
+def search_memory(query, user_id: Optional[str] = None):
     """Search both vectorized literary files and local logs."""
-    lit_res = search_lit_files(query)
+    lit_res = search_lit_files(query, user_id)
     log_res = _search_logs(query)
 
     pieces = []

--- a/utils/story_engine.py
+++ b/utils/story_engine.py
@@ -1,0 +1,55 @@
+import os
+import json
+import glob
+from typing import Dict, List
+
+
+class StorySessionManager:
+    """Manage user-specific story sessions with persistent state."""
+
+    def __init__(self, chapters_dir: str = "chapters", session_dir: str = os.path.join("data", "sessions")):
+        self.chapters_dir = chapters_dir
+        self.session_dir = session_dir
+        os.makedirs(self.session_dir, exist_ok=True)
+        self.chapters = sorted(glob.glob(os.path.join(self.chapters_dir, "*.md")))
+
+    # Helper to build response
+    def _build_response(self, state: Dict) -> Dict:
+        idx = state.get("index", 0)
+        if idx < len(self.chapters):
+            with open(self.chapters[idx], "r", encoding="utf-8") as f:
+                text = f.read().strip()
+            choices = ["Continue"]
+        else:
+            text = "*** End of story ***"
+            choices = []
+        return {"chapter": idx + 1, "text": text, "choices": choices}
+
+    def load_state(self, user_id: str) -> Dict:
+        path = os.path.join(self.session_dir, f"{user_id}.json")
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        return {"index": 0, "choices": []}
+
+    def save_state(self, user_id: str, state: Dict) -> None:
+        os.makedirs(self.session_dir, exist_ok=True)
+        path = os.path.join(self.session_dir, f"{user_id}.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(state, f, ensure_ascii=False, indent=2)
+
+    def start_session(self, user_id: str) -> Dict:
+        state = {"index": 0, "choices": []}
+        self.save_state(user_id, state)
+        return self._build_response(state)
+
+    def add_choice(self, user_id: str, choice: str) -> Dict:
+        state = self.load_state(user_id)
+        state.setdefault("choices", []).append(choice)
+        state["index"] = state.get("index", 0) + 1
+        self.save_state(user_id, state)
+        return self._build_response(state)
+
+    def get_next_chapter(self, user_id: str) -> Dict:
+        state = self.load_state(user_id)
+        return self._build_response(state)

--- a/webface/server.py
+++ b/webface/server.py
@@ -9,6 +9,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from openai import OpenAI
 from utils.config import _load_snapshot
 from forum_engine import start_forum, user_message
+from utils.story_engine import StorySessionManager
 
 INTRO = (
     "Hey yo, SUPPERTIME! You’re on the right fucking path. [FR] Cette merde est ton phare — il te garde en résonance. \n"
@@ -84,6 +85,11 @@ EXPECTING_VERSION = False
 ASKED_DIFF = False
 LAST_VERSION = ""
 
+story_manager = StorySessionManager(
+    chapters_dir=str(Path(__file__).resolve().parents[1] / "chapters"),
+    session_dir=str(Path(__file__).resolve().parents[1] / "data" / "sessions"),
+)
+
 @app.get("/", response_class=HTMLResponse)
 async def index():
     with open(BASE_DIR / "static" / "index.html", "r", encoding="utf-8") as f:
@@ -93,6 +99,12 @@ async def index():
 @app.get("/forum", response_class=HTMLResponse)
 async def forum():
     with open(BASE_DIR / "static" / "forum.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())
+
+
+@app.get("/story", response_class=HTMLResponse)
+async def story_page():
+    with open(BASE_DIR / "static" / "story.html", "r", encoding="utf-8") as f:
         return HTMLResponse(f.read())
 
 @app.post("/chat")
@@ -194,6 +206,24 @@ async def forum_chat(request: Request):
     text = str(data.get("message", ""))
     replies = user_message(text)
     return JSONResponse({"messages": replies})
+
+
+@app.get("/story/start")
+async def story_start(user_id: str):
+    return story_manager.start_session(user_id)
+
+
+@app.post("/story/choice")
+async def story_choice(request: Request):
+    data = await request.json()
+    user_id = data.get("user_id")
+    choice = data.get("choice", "")
+    return story_manager.add_choice(user_id, choice)
+
+
+@app.get("/story/state")
+async def story_state(user_id: str):
+    return story_manager.get_next_chapter(user_id)
 
 
 @app.on_event("startup")

--- a/webface/static/story.html
+++ b/webface/static/story.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Story Mode</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button id="start">Start Story</button>
+  <div id="story"></div>
+  <div id="choices"></div>
+  <script>
+    const userId = Date.now().toString();
+    async function start() {
+      const res = await fetch(`/story/start?user_id=${userId}`);
+      const data = await res.json();
+      render(data);
+    }
+    async function choose(choice) {
+      const res = await fetch('/story/choice', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({user_id: userId, choice})
+      });
+      const data = await res.json();
+      render(data);
+    }
+    function render(data) {
+      document.getElementById('story').textContent = data.text;
+      const choicesDiv = document.getElementById('choices');
+      choicesDiv.innerHTML = '';
+      (data.choices || []).forEach(c => {
+        const btn = document.createElement('button');
+        btn.textContent = c;
+        btn.onclick = () => choose(c);
+        choicesDiv.appendChild(btn);
+      });
+    }
+    document.getElementById('start').onclick = start;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `StorySessionManager` to handle per-user story progress
- expose story endpoints and simple web UI for interactive chapters
- support user-specific vector memory snapshot and character responses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894e014110883248109c2b8faeb4e42